### PR TITLE
[CM-879] - expose methods - updateConversationAssignee and updateConversationInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+## [Unreleased]
+
+- Exposed methods to iOS: updateConversationAssignee and updateConversationInfo
+```javascript
+    RNKommunicateChat.updateConversationAssignee({
+            clientConversationId: "<clientconversationid>",
+            conversationAssignee: "<assignee email>"}, (success, error) => {
+                console.log("Updated conversation assignee");
+            });
+
+    RNKommunicateChat.updateConversationInfo({
+            clientConversationId: "<client conversation id>",
+            conversationInfo: {
+            "test1": "value1",
+            "test2": "value2"
+            }
+        }, (success, error) => {
+            console.log("Updated conversation info");
+            });
+```

--- a/RNKommunicateChat.podspec
+++ b/RNKommunicateChat.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'React'
-  s.dependency 'Kommunicate', '~> 6.6.0'
+  s.dependency 'Kommunicate', '~> 6.7.1'
 end

--- a/ios/RNKommunicateChat.swift
+++ b/ios/RNKommunicateChat.swift
@@ -335,7 +335,26 @@ class RNKommunicateChat : NSObject, KMPreChatFormViewControllerDelegate {
     
     @objc
     func updateConversationAssignee(_ assigneeData: Dictionary<String, Any>, _ callback: @escaping RCTResponseSenderBlock) -> Void {
-        callback(["Error", "Method not implemented"])
+        guard let assignee = assigneeData["conversationInfo"] as? String else {
+            callback(["Error", "Conversation Assignee is empty or invalid"])
+            return
+        }
+        guard let clientConversationId = assigneeData["clientConversationId"] as? String else {
+            callback(["Error", "clientConversationId is empty or invalid"])
+            return
+        }
+        
+        let conversation = KMConversationBuilder().withClientConversationId(clientConversationId)
+            .withConversationAssignee(assignee).build()
+        
+        Kommunicate.updateConversation(conversation: conversation) { response in
+            switch response {
+            case .success(let clientConversationId):
+                callback(["Success", "Successfully updated conversation Assignee"])
+            case .failure(let error):
+                callback(["Error", "Could not update Conversation Assignee"])
+            }
+        }
     }
     
     @objc
@@ -366,7 +385,27 @@ class RNKommunicateChat : NSObject, KMPreChatFormViewControllerDelegate {
     
     @objc
     func updateConversationInfo(_ infoData: Dictionary<String, Any>, _ callback: @escaping RCTResponseSenderBlock) -> Void {
-        callback(["Error", "Method not implemented"])
+        
+        guard let conversationInfo = infoData["conversationInfo"] as? Dictionary<String, Any> else {
+            callback(["Error", "Conversation Info is empty or invalid"])
+            return
+        }
+        guard let clientConversationId = infoData["clientConversationId"] as? String else {
+            callback(["Error", "clientConversationId is empty or invalid"])
+            return
+        }
+        
+        let conversation = KMConversationBuilder().withClientConversationId(clientConversationId)
+            .withMetaData(conversationInfo).build()
+        
+        Kommunicate.updateConversation(conversation: conversation) { response in
+            switch response {
+            case .success(let clientConversationId):
+                callback(["Success", "Successfully updated conversation info"])
+            case .failure(let error):
+                callback(["Error", "Could not update Conversation Info"])
+            }
+        }
     }
     
     func closeButtonTapped() {

--- a/ios/RNKommunicateChat.swift
+++ b/ios/RNKommunicateChat.swift
@@ -335,7 +335,7 @@ class RNKommunicateChat : NSObject, KMPreChatFormViewControllerDelegate {
     
     @objc
     func updateConversationAssignee(_ assigneeData: Dictionary<String, Any>, _ callback: @escaping RCTResponseSenderBlock) -> Void {
-        guard let assignee = assigneeData["conversationInfo"] as? String else {
+        guard let assignee = assigneeData["conversationAssignee"] as? String else {
             callback(["Error", "Conversation Assignee is empty or invalid"])
             return
         }
@@ -352,7 +352,7 @@ class RNKommunicateChat : NSObject, KMPreChatFormViewControllerDelegate {
             case .success(let clientConversationId):
                 callback(["Success", "Successfully updated conversation Assignee"])
             case .failure(let error):
-                callback(["Error", "Could not update Conversation Assignee"])
+                callback(["Error", error.localizedDescription])
             }
         }
     }
@@ -403,7 +403,7 @@ class RNKommunicateChat : NSObject, KMPreChatFormViewControllerDelegate {
             case .success(let clientConversationId):
                 callback(["Success", "Successfully updated conversation info"])
             case .failure(let error):
-                callback(["Error", "Could not update Conversation Info"])
+                callback(["Error", error.localizedDescription])
             }
         }
     }


### PR DESCRIPTION
## updateConversationAssignee :
```javascript
RNKommunicateChat.updateConversationAssignee({
          clientConversationId: "<clientconversationid>",
          conversationAssignee: "<assignee email>"}, (success, error) => {
            console.log("Updated conversation assignee");
          });
```
          
## updateConversationInfo :
```javascript
RNKommunicateChat.updateConversationInfo({
        clientConversationId: "<client conversation id>",
        conversationInfo: {
          "test1": "value1",
          "test2": "value2"
        }
      }, (success, error) => {
          console.log("Updated conversation info");
        });
```