### PR TITLE
release changes for v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## React Native Kommunicate Chat v2.0.0
 - Added support for listening to Events - Android only
  ```javascript
     const eventEmitter = new NativeEventEmitter(RNKommunicateChat);
@@ -7,6 +7,13 @@
     });
  ```
  For more events, refer to our docs
+ - Expose method to close Kommunicate screen - ```RNKommunicateChat.closeConversationScreen()```
+ - Typing Indicator Design Changed - Android
+ - Added Support for Android API 33
+ - Added support for AES256 encryption and decryption
+ - Added multiple customization option
+ - Multiple bug fixes and optimization
+
 
 ## React Native Kommunicate Chat v1.6.8
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,11 +16,11 @@ rootProject.allprojects {
     }
 }
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }
@@ -35,5 +35,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.kommunicate.sdk:kommunicateui:2.5.3'
+    api 'io.kommunicate.sdk:kommunicateui:2.6.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-kommunicate-chat",
-  "version": "1.6.8",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -9,9 +9,6 @@
   "keywords": [
     "react-native"
   ],
-  "author": "",
-  "license": "",
-  "peerDependencies": {
-    "react-native": "^0.63.3"
-  }
+  "author": "codemonk@kommunicate.io",
+  "license": ""
 }


### PR DESCRIPTION
## React Native Kommunicate Chat v2.0.0
- Added support for listening to Events - Android only
 ```javascript
    const eventEmitter = new NativeEventEmitter(RNKommunicateChat);
    const eventListener = eventEmitter.addListener("onPluginLaunch", event => {
        console.log("onPluginLaunch" );
    });
 ```
 For more events, refer to our docs
 - Expose method to close Kommunicate screen - ```RNKommunicateChat.closeConversationScreen()```
 - Typing Indicator Design Changed - Android
 - Added Support for Android API 33
 - Added support for AES256 encryption and decryption
 - Added multiple customization option
 - Multiple bug fixes and optimization