### PR TITLE
release changes for v2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## React Native Kommunicate Chat v2.1.5
+- Exposed enableSpeechToText() method which will create UI for multiple speech to text language - iOS
+- Added customizable option to disable chat widget in Helpcenter "hideChatInHelpcenter"
+- Attachment name and icon improvement - Android
+- Added support to delete conversation for end-user - Android
+
 ## React Native Kommunicate Chat v2.1.0
 - Exposed createSettings() methods which will create settings for both Android and iOS
 - Exposed enableSpeechToText() method which will create UI for multiple speech to text language - Android

--- a/RNKommunicateChat.podspec
+++ b/RNKommunicateChat.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'React'
-  s.dependency 'Kommunicate', '~> 6.7.9'
+  s.dependency 'Kommunicate', '~> 6.8.4'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.kommunicate.sdk:kommunicateui:2.6.5'
+    api 'io.kommunicate.sdk:kommunicateui:2.6.7'
 }

--- a/ios/RNKommunicateChat.m
+++ b/ios/RNKommunicateChat.m
@@ -29,6 +29,7 @@ RCT_EXTERN_METHOD (updateTeamId: (NSDictionary<NSString *, id> * _Nonnull)teamDa
 RCT_EXTERN_METHOD (updateConversationInfo: (NSDictionary<NSString *, id> * _Nonnull)infoData :(RCTResponseSenderBlock _Nonnull)callback);
 RCT_EXTERN_METHOD (closeConversationScreen: );
 RCT_EXTERN_METHOD (createSettings: );
+RCT_EXTERN_METHOD (enableSpeechToText: (NSDictionary<NSString *, id> * _Nonnull)infoData :(RCTResponseSenderBlock _Nonnull)callback);
 
 
 + (BOOL)requiresMainQueueSetup { return YES; }

--- a/ios/RNKommunicateChat.swift
+++ b/ios/RNKommunicateChat.swift
@@ -414,9 +414,23 @@ class RNKommunicateChat : RCTEventEmitter, KMPreChatFormViewControllerDelegate, 
         }
     }
 
-    @objc
+    @objc 
     func createSettings(_ settingString: String) {
          Kommunicate.createSettings(settings: settingString)
+    }
+
+    @objc
+    func enableSpeechToText(_ data: Dictionary<String, Any>, _ callback: @escaping RCTResponseSenderBlock) -> Void {
+        do {
+            if let languages = (data[RNKommunicateChat.KM_LANGUAGES] as? String)?.data(using: .utf8), let languageData = try JSONSerialization.jsonObject(with: languages, options : .allowFragments) as? Dictionary<String,String> {
+                    Kommunicate.defaultConfiguration.languagesForSpeechToText = languageData
+                            callback(["Success", "Successfully enabled speech to text"])
+                            return;
+                }
+        }
+        catch {
+            callback(["Error", "Invalid language data"])
+        }
     }
     
     func closeButtonTapped() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-kommunicate-chat",
-  "version": "2.1.0",
+  "version": "2.1.5",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## React Native Kommunicate Chat v2.1.5
- Exposed enableSpeechToText() method which will create UI for multiple speech to text language - iOS
- Added customizable option to disable chat widget in Helpcenter "hideChatInHelpcenter"
- Attachment name and icon improvement - Android
- Added support to delete conversation for end-user - Android