### PR TITLE
[CM-1357] - Expose updateDefaultSetting method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## React Native Kommunicate Chat v2.1.8
+- Upgraded iOS SDK to 6.8.9
+- Fixed event data mismatch
+
 ## React Native Kommunicate Chat v2.1.7
 - Upgraded iOS SDK to 6.8.8
 - Upgraded Android SDK to 2.7.0

--- a/RNKommunicateChat.podspec
+++ b/RNKommunicateChat.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'React'
-  s.dependency 'Kommunicate', '~> 6.8.8'
+  s.dependency 'Kommunicate', '~> 6.8.9'
 end

--- a/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
+++ b/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
@@ -25,6 +25,7 @@ import com.applozic.mobicommons.file.FileUtils;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Arrays;
 
 import io.kommunicate.KmConversationHelper;
 import io.kommunicate.KmException;
@@ -505,20 +506,16 @@ public class RNKommunicateChatModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void updateDefaultSetting(final ReadableMap settingMap, final Callback callback) {
         final Activity currentActivity = getCurrentActivity();
-try {
+            try {
                 KmSettings.clearDefaultSettings();
                 if (settingMap.hasKey("defaultAgentIds")) {
                     List<String> agentList = new ArrayList<String>();
-                    for(int i = 0; i < settingMap.getArray("defaultAgentIds").size(); i++){
-                        agentList.add(settingMap.getArray("defaultAgentIds").getString(i));
-                    }
+                    agentList = Arrays.asList(settingMap.getArray("defaultAgentIds"));
                     KmSettings.setDefaultAgentIds(agentList);
                 }
                 if (settingMap.hasKey("defaultBotIds")) {
                     List<String> botList = new ArrayList<String>();
-                    for(int i = 0; i < settingMap.getArray("defaultBotIds").size(); i++){
-                        botList.add(settingMap.getArray("defaultBotIds").getString(i));
-                    }
+                    botList = Arrays.asList(settingMap.getArray("defaultBotIds"));
                     KmSettings.setDefaultBotIds(botList);
                 }
                 if (settingMap.hasKey("defaultAssignee")) {

--- a/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
+++ b/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
@@ -25,7 +25,6 @@ import com.applozic.mobicommons.file.FileUtils;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Arrays;
 
 import io.kommunicate.KmConversationHelper;
 import io.kommunicate.KmException;
@@ -509,11 +508,17 @@ public class RNKommunicateChatModule extends ReactContextBaseJavaModule {
             try {
                 KmSettings.clearDefaultSettings();
                 if (settingMap.hasKey("defaultAgentIds")) {
-                    List<String> agentList = new ArrayList<String>(Arrays.asList(settingMap.getArray("defaultAgentIds")));
+                    List<String> agentList = new ArrayList<String>();
+                    for(int i = 0; i < settingMap.getArray("defaultAgentIds").size(); i++){
+                        agentList.add(settingMap.getArray("defaultAgentIds").getString(i));
+                    }
                     KmSettings.setDefaultAgentIds(agentList);
                 }
                 if (settingMap.hasKey("defaultBotIds")) {
-                    List<String> botList = new ArrayList<String>(Arrays.asList(settingMap.getArray("defaultBotIds")));
+                    List<String> botList = new ArrayList<String>();
+                    for(int i = 0; i < settingMap.getArray("defaultBotIds").size(); i++){
+                        botList.add(settingMap.getArray("defaultBotIds").getString(i));
+                    }
                     KmSettings.setDefaultBotIds(botList);
                 }
                 if (settingMap.hasKey("defaultAssignee")) {

--- a/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
+++ b/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
@@ -499,6 +499,43 @@ public class RNKommunicateChatModule extends ReactContextBaseJavaModule {
         FileUtils.writeSettingsToFile(currentActivity, setting);
     }
 
+    @ReactMethod
+    public void updateDefaultSetting(final ReadableMap settingObject) {
+        final Activity currentActivity = getCurrentActivity();
+try {
+                KmSettings.clearDefaultSettings();
+                JSONObject settingObject = new JSONObject(call.arguments.toString());
+                if (settingObject.hasKey("defaultAgentIds") && !TextUtils.isEmpty(settingObject.getString("defaultAgentIds").toString())) {
+                    List<String> agentList = new ArrayList<String>();
+                    for(int i = 0; i < settingObject.getJSONArray("defaultAgentIds").length(); i++){
+                        agentList.add(settingObject.getJSONArray("defaultAgentIds").get(i).toString());
+                    }
+                    KmSettings.setDefaultAgentIds(agentList);
+                }
+                if (settingObject.hasKey("defaultBotIds") && !TextUtils.isEmpty(settingObject.get("defaultBotIds").toString())) {
+                    List<String> botList = new ArrayList<String>();
+                    for(int i = 0; i < settingObject.getJSONArray("defaultBotIds").length(); i++){
+                        botList.add(settingObject.getJSONArray("defaultBotIds").get(i).toString());
+                    }
+                    KmSettings.setDefaultBotIds(botList);
+                }
+                if (settingObject.hasKey("defaultAssignee") && !TextUtils.isEmpty(settingObject.get("defaultAssignee").toString())) {
+                    KmSettings.setDefaultAssignee(settingObject.get("defaultAssignee").toString());
+                }
+                if (settingObject.hasKey("teamId")) {
+                    KmSettings.setDefaultTeamId(settingObject.get("teamId").toString());
+                }
+                if (settingObject.hasKey("skipRouting")) {
+                    KmSettings.setSkipRouting(Boolean.valueOf(settingObject.get("skipRouting").toString()));
+                }
+                    callback.invoke(SUCCESS);
+
+            } catch(Exception e) {
+                callback.invoke(ERROR, e.toString());
+            }
+
+    }
+
     static class KmInfoProcessor {
         private String clientConversationId;
         private Integer conversationId;

--- a/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
+++ b/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
@@ -43,8 +43,6 @@ import java.util.List;
 import java.util.ArrayList;
 import org.json.JSONObject;
 
-
-
 public class RNKommunicateChatModule extends ReactContextBaseJavaModule {
 
     private static final String SUCCESS = "Success";

--- a/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
+++ b/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.text.TextUtils;
 
+
 import com.applozic.mobicomkit.api.account.register.RegistrationResponse;
 import com.applozic.mobicomkit.api.account.user.AlUserUpdateTask;
 import com.applozic.mobicomkit.api.account.user.MobiComUserPreference;
@@ -38,6 +39,11 @@ import io.kommunicate.KmConversationBuilder;
 import com.applozic.mobicomkit.uiwidgets.kommunicate.settings.KmSpeechToTextSetting;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import org.json.JSONObject;
+
+
 
 public class RNKommunicateChatModule extends ReactContextBaseJavaModule {
 
@@ -500,36 +506,34 @@ public class RNKommunicateChatModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void updateDefaultSetting(final ReadableMap settingObject) {
+    public void updateDefaultSetting(final ReadableMap settingMap, final Callback callback) {
         final Activity currentActivity = getCurrentActivity();
 try {
                 KmSettings.clearDefaultSettings();
-                JSONObject settingObject = new JSONObject(call.arguments.toString());
-                if (settingObject.hasKey("defaultAgentIds") && !TextUtils.isEmpty(settingObject.getString("defaultAgentIds").toString())) {
+                if (settingMap.hasKey("defaultAgentIds")) {
                     List<String> agentList = new ArrayList<String>();
-                    for(int i = 0; i < settingObject.getJSONArray("defaultAgentIds").length(); i++){
-                        agentList.add(settingObject.getJSONArray("defaultAgentIds").get(i).toString());
+                    for(int i = 0; i < settingMap.getArray("defaultAgentIds").size(); i++){
+                        agentList.add(settingMap.getArray("defaultAgentIds").getString(i));
                     }
                     KmSettings.setDefaultAgentIds(agentList);
                 }
-                if (settingObject.hasKey("defaultBotIds") && !TextUtils.isEmpty(settingObject.get("defaultBotIds").toString())) {
+                if (settingMap.hasKey("defaultBotIds")) {
                     List<String> botList = new ArrayList<String>();
-                    for(int i = 0; i < settingObject.getJSONArray("defaultBotIds").length(); i++){
-                        botList.add(settingObject.getJSONArray("defaultBotIds").get(i).toString());
+                    for(int i = 0; i < settingMap.getArray("defaultBotIds").size(); i++){
+                        botList.add(settingMap.getArray("defaultBotIds").getString(i));
                     }
                     KmSettings.setDefaultBotIds(botList);
                 }
-                if (settingObject.hasKey("defaultAssignee") && !TextUtils.isEmpty(settingObject.get("defaultAssignee").toString())) {
-                    KmSettings.setDefaultAssignee(settingObject.get("defaultAssignee").toString());
+                if (settingMap.hasKey("defaultAssignee")) {
+                    KmSettings.setDefaultAssignee(settingMap.getString("defaultAssignee"));
                 }
-                if (settingObject.hasKey("teamId")) {
-                    KmSettings.setDefaultTeamId(settingObject.get("teamId").toString());
+                if (settingMap.hasKey("teamId")) {
+                    KmSettings.setDefaultTeamId(settingMap.getString("teamId"));
                 }
-                if (settingObject.hasKey("skipRouting")) {
-                    KmSettings.setSkipRouting(Boolean.valueOf(settingObject.get("skipRouting").toString()));
+                if (settingMap.hasKey("skipRouting")) {
+                    KmSettings.setSkipRouting(settingMap.getBoolean("skipRouting"));
                 }
-                    callback.invoke(SUCCESS);
-
+                    callback.invoke(SUCCESS, "Successfully set default settings");
             } catch(Exception e) {
                 callback.invoke(ERROR, e.toString());
             }

--- a/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
+++ b/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
@@ -509,13 +509,11 @@ public class RNKommunicateChatModule extends ReactContextBaseJavaModule {
             try {
                 KmSettings.clearDefaultSettings();
                 if (settingMap.hasKey("defaultAgentIds")) {
-                    List<String> agentList = new ArrayList<String>();
-                    agentList = Arrays.asList(settingMap.getArray("defaultAgentIds"));
+                    List<String> agentList = new ArrayList<String>(settingMap.getArray("defaultAgentIds"));
                     KmSettings.setDefaultAgentIds(agentList);
                 }
                 if (settingMap.hasKey("defaultBotIds")) {
-                    List<String> botList = new ArrayList<String>();
-                    botList = Arrays.asList(settingMap.getArray("defaultBotIds"));
+                    List<String> botList = new ArrayList<String>(settingMap.getArray("defaultBotIds"));
                     KmSettings.setDefaultBotIds(botList);
                 }
                 if (settingMap.hasKey("defaultAssignee")) {

--- a/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
+++ b/android/src/main/java/io/kommunicate/app/RNKommunicateChatModule.java
@@ -509,11 +509,11 @@ public class RNKommunicateChatModule extends ReactContextBaseJavaModule {
             try {
                 KmSettings.clearDefaultSettings();
                 if (settingMap.hasKey("defaultAgentIds")) {
-                    List<String> agentList = new ArrayList<String>(settingMap.getArray("defaultAgentIds"));
+                    List<String> agentList = new ArrayList<String>(Arrays.asList(settingMap.getArray("defaultAgentIds")));
                     KmSettings.setDefaultAgentIds(agentList);
                 }
                 if (settingMap.hasKey("defaultBotIds")) {
-                    List<String> botList = new ArrayList<String>(settingMap.getArray("defaultBotIds"));
+                    List<String> botList = new ArrayList<String>(Arrays.asList(settingMap.getArray("defaultBotIds")));
                     KmSettings.setDefaultBotIds(botList);
                 }
                 if (settingMap.hasKey("defaultAssignee")) {

--- a/ios/RNKommunicateChat.m
+++ b/ios/RNKommunicateChat.m
@@ -30,6 +30,7 @@ RCT_EXTERN_METHOD (updateConversationInfo: (NSDictionary<NSString *, id> * _Nonn
 RCT_EXTERN_METHOD (closeConversationScreen: );
 RCT_EXTERN_METHOD (createSettings: );
 RCT_EXTERN_METHOD (enableSpeechToText: (NSDictionary<NSString *, id> * _Nonnull)infoData :(RCTResponseSenderBlock _Nonnull)callback);
+RCT_EXTERN_METHOD (updateDefaultSetting: (NSDictionary<NSString *, id> * _Nonnull)settingData :(RCTResponseSenderBlock _Nonnull)callback);
 
 
 + (BOOL)requiresMainQueueSetup { return YES; }

--- a/ios/RNKommunicateChat.swift
+++ b/ios/RNKommunicateChat.swift
@@ -439,11 +439,11 @@ class RNKommunicateChat : RCTEventEmitter, KMPreChatFormViewControllerDelegate, 
     func updateDefaultSetting(_ settingDict: Dictionary<String, Any>, _ callback: @escaping RCTResponseSenderBlock) -> Void {
         do {
             Kommunicate.defaultConfiguration.clearDefaultConversationSettings()
-            if(settingDict["defaultAssignee"] != nil) {
-                Kommunicate.defaultConfiguration.defaultAssignee = settingDict["defaultAssignee"] as? String
+            if let defaultAssignee = settingDict["defaultAssignee"] as? String, !defaultAssignee.isEmpty {
+                Kommunicate.defaultConfiguration.defaultAssignee = defaultAssignee
             }
-            if(settingDict["teamId"] != nil) {
-                Kommunicate.defaultConfiguration.defaultTeamId = settingDict["teamId"] as? String
+            if let teamId = settingDict["teamId"] as? String, !teamId.isEmpty {
+                Kommunicate.defaultConfiguration.defaultTeamId = teamId
             }
             if let skipRouting = settingDict["skipRouting"] as? Bool {
                 Kommunicate.defaultConfiguration.defaultSkipRouting = skipRouting

--- a/ios/RNKommunicateChat.swift
+++ b/ios/RNKommunicateChat.swift
@@ -435,6 +435,31 @@ class RNKommunicateChat : RCTEventEmitter, KMPreChatFormViewControllerDelegate, 
         }
     }
     
+    @objc
+    func updateDefaultSetting(_ settingDict: Dictionary<String, Any>, _ callback: @escaping RCTResponseSenderBlock) -> Void {
+        do {
+            Kommunicate.defaultConfiguration.clearDefaultConversationSettings()
+            if(settingDict["defaultAssignee"] != nil) {
+                Kommunicate.defaultConfiguration.defaultAssignee = settingDict["defaultAssignee"] as? String
+            }
+            if(settingDict["teamId"] != nil) {
+                Kommunicate.defaultConfiguration.defaultTeamId = settingDict["teamId"] as? String
+            }
+            if let skipRouting = settingDict["skipRouting"] as? Bool {
+                Kommunicate.defaultConfiguration.defaultSkipRouting = skipRouting
+            }
+            if let agentIds = settingDict["defaultAgentIds"] as? [String], !agentIds.isEmpty {
+                Kommunicate.defaultConfiguration.defaultAgentIds = agentIds
+            }
+            if let botIds = settingDict["defaultBotIds"] as? [String], !botIds.isEmpty {
+                Kommunicate.defaultConfiguration.defaultBotIds = botIds
+            }
+        }
+        catch {
+            callback(["Error", "Invalid language data"])
+        }
+    }
+
     func closeButtonTapped() {
         UIApplication.topViewController()?.dismiss(animated: false, completion: nil)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-kommunicate-chat",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What do you want to achieve?
- updateDefaultSetting method is available in Android and iOS, which changes the default setting of a conversation.
- When "Start new Conversation"  is clicked from conversation list screen then these settings are used.
- Exposed a method "updateDefaultSetting" which would update the setting for both Android and iOS.

## How to implement:
- Pass a dynamic setting object to "RNKommunicateChat.updateDefaultSetting" which contains the setting to be passed.

## React Native Javascript code:
```javascript
var setting = {
        "defaultAgentIds": ["amantoppo3199@gmail.com", "amantoppo@kommunicate.io"], //list of agentID
        "defaultBotIds": ["bot-e8xil"], // list of BotID
        "defaultAssignee": "amantoppo3199@gmail.com", 
        "skipRouting": true,
        "teamId": "63641656"
        };
RNKommunicateChat.updateDefaultSetting(setting, (status, message) => {
          console.log(message);
});
```


