### PR TITLE
[CM-1464] - closeConversationScreen not working 

### DIFF
--- a/ios/RNKommunicateChat.m
+++ b/ios/RNKommunicateChat.m
@@ -27,8 +27,8 @@ RCT_EXTERN_METHOD (updateUserDetails: (NSDictionary<NSString *, id> * _Nonnull)k
 RCT_EXTERN_METHOD (updateConversationAssignee: (NSDictionary<NSString *, id> * _Nonnull)assigneeData :(RCTResponseSenderBlock _Nonnull)callback);
 RCT_EXTERN_METHOD (updateTeamId: (NSDictionary<NSString *, id> * _Nonnull)teamData :(RCTResponseSenderBlock _Nonnull)callback);
 RCT_EXTERN_METHOD (updateConversationInfo: (NSDictionary<NSString *, id> * _Nonnull)infoData :(RCTResponseSenderBlock _Nonnull)callback);
-RCT_EXTERN_METHOD (closeConversationScreen: );
-RCT_EXTERN_METHOD (createSettings: );
+RCT_EXTERN_METHOD (closeConversationScreen);
+RCT_EXTERN_METHOD (createSettings: (NSString * _Nonnull) );
 RCT_EXTERN_METHOD (enableSpeechToText: (NSDictionary<NSString *, id> * _Nonnull)infoData :(RCTResponseSenderBlock _Nonnull)callback);
 
 


### PR DESCRIPTION
For some versions of React Native, for example, 0.71.4, the closeConversationScreen is not working

- Changed it to support all versions