### PR TITLE
release changes for v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## React Native Kommunicate Chat v2.2.0
+- Added support for Default Settings -
+```javascript
+- var setting = {
+         "defaultAgentIds": [""], //list of agentID
+        "defaultBotIds": [""], // list of BotID
+        "defaultAssignee": "amantoppo3199@gmail.com", //string of conversation Assignee
+        "skipRouting": true, // If you pass this value true then it will skip routing rules set from conversation rules section.
+         "teamId": "<pass any teamID>"
+        };
+        RNKommunicateChat.updateDefaultSetting(setting, (status, message) => {
+          console.log(message);
+        });
+```
+- Fixed closeConversatioNScreen not working in iOS
+
 ## React Native Kommunicate Chat v2.1.8
 - Upgraded iOS SDK to 6.8.9
 - Fixed event data mismatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## React Native Kommunicate Chat v2.2.0
 - Added support for Default Settings -
 ```javascript
-- var setting = {
+var setting = {
          "defaultAgentIds": [""], //list of agentID
         "defaultBotIds": [""], // list of BotID
         "defaultAssignee": "amantoppo3199@gmail.com", //string of conversation Assignee

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-kommunicate-chat",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## React Native Kommunicate Chat v2.2.0
- Added support for Default Settings -
```javascript
var setting = {
         "defaultAgentIds": [""], //list of agentID
        "defaultBotIds": [""], // list of BotID
        "defaultAssignee": "amantoppo3199@gmail.com", //string of conversation Assignee
        "skipRouting": true, // If you pass this value true then it will skip routing rules set from conversation rules section.
         "teamId": "<pass any teamID>"
        };
        RNKommunicateChat.updateDefaultSetting(setting, (status, message) => {
          console.log(message);
        });
```
- Fixed closeConversatioNScreen not working in iOS