### PR TITLE
release changes for v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## React Native Kommunicate Chat v2.2.3
+- Fixed visibility of startNewConversation button
+- Added support for API Suggestions
+- Added "showTypingIndicatorWhileFetchingResponse" settings to show typing indicator when bot fetching response
+- Crashes fixed
+
 ## React Native Kommunicate Chat v2.2.1
 - UI/UX changes to match Android and iOS
 - Added support for Custom Input Field - Android

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.kommunicate.sdk:kommunicateui:2.7.4'
+    api 'io.kommunicate.sdk:kommunicateui:2.7.6'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-kommunicate-chat",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## React Native Kommunicate Chat v2.2.3
- Fixed visibility of startNewConversation button
- Added support for API Suggestions
- Added "showTypingIndicatorWhileFetchingResponse" settings to show typing indicator when bot fetching response
- Crashes fixed