### PR TITLE
Release v2.5.6 with iOS 26 bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# React Native Kommunicate Chat v2.5.6
+- [iOS] Fixed the glass effect bug with iOS 26 versions.
+- [iOS] Fixed dark icon issue with iOS 26 versions.
 # React Native Kommunicate Chat v2.5.5
 - [Android] Fixed Runtime Exception Bug. Added proactive checks to avoid NPE.
 # React Native Kommunicate Chat v2.5.4

--- a/RNKommunicateChat.podspec
+++ b/RNKommunicateChat.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m,swift}"
   s.requires_arc = true
   s.dependency 'React'
-  s.dependency 'Kommunicate', '7.3.1'
+  s.dependency 'Kommunicate', '7.3.2'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-kommunicate-chat",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
* Updated `Kommunicate` iOS dependency to version **7.3.2**.
* Bumped package version to **2.5.6**.
* Fixed glass effect and dark icon issues on **iOS 26**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed glass effect rendering issue on iOS 26 devices
  * Resolved dark icon display issue on iOS 26 devices
  * Updated backend dependencies for improved stability

**Version 2.5.6**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->