### PR TITLE
Release-2.3.11: Crash Fix Patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# React Native Kommunicate Chat v2.3.11.1
+# React Native Kommunicate Chat v2.3.12
 - [Android] Crash Fix patch for v2.3.11
 # React Native Kommunicate Chat v2.5.7
 - [Android] Fixed assignee names do not update if clientConversationId is set in buildConversation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# React Native Kommunicate Chat v2.3.11.1
+- [Android] Crash Fix patch for v2.3.11
 # React Native Kommunicate Chat v2.5.7
 - [Android] Fixed assignee names do not update if clientConversationId is set in buildConversation.
 - [iOS] Fixed SPM Build Issue.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.kommunicate.sdk:kommunicateui:2.14.5'
+    api 'io.kommunicate.sdk:kommunicateui:2.10.8.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-kommunicate-chat",
-  "version": "2.5.7",
+  "version": "2.3.12",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Summary
Do not try to update UI if message does not groupId or contactIds in payload.

### Exception
Fatal Exception: java.lang.IllegalArgumentException: the bind value at index 1 is null
       at net.sqlcipher.database.SQLiteProgram.bindString(SQLiteProgram.java:258)
       at net.sqlcipher.database.SQLiteQuery.bindString(SQLiteQuery.java:192)
       at net.sqlcipher.database.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:66)
       at net.sqlcipher.database.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:2016)
       at net.sqlcipher.database.SQLiteDatabase.queryWithFactory(SQLiteDatabase.java:1799)
       at net.sqlcipher.database.SQLiteDatabase.query(SQLiteDatabase.java:1751)
       at net.sqlcipher.database.SQLiteDatabase.query(SQLiteDatabase.java:1883)
       at com.applozic.mobicomkit.api.conversation.database.MessageDatabaseService.getLatestMessage(MessageDatabaseService.java:877)
       at com.applozic.mobicomkit.uiwidgets.conversation.fragment.MobiComQuickConversationFragment.updateLastMessage(MobiComQuickConversationFragment.java:450)
       at com.applozic.mobicomkit.uiwidgets.conversation.ConversationUIService.updateLastMessage(ConversationUIService.java:526)
       at com.applozic.mobicomkit.uiwidgets.conversation.ConversationUIService.syncMessages(ConversationUIService.java:517)
       at com.applozic.mobicomkit.uiwidgets.conversation.MobiComKitBroadcastReceiver.onReceive(MobiComKitBroadcastReceiver.java:95)
       at androidx.localbroadcastmanager.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:313)
       at androidx.localbroadcastmanager.content.LocalBroadcastManager$1.handleMessage(LocalBroadcastManager.java:121)
       at android.os.Handler.dispatchMessage(Handler.java:112)
       at android.os.Looper.loopOnce(Looper.java:288)
       at android.os.Looper.loop(Looper.java:393)
       at android.app.ActivityThread.main(ActivityThread.java:9564)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:600)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1010)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an Android crash affecting v2.3.11 users.

* **Chores**
  * Bumped release version to v2.3.12.
  * Updated Android SDK dependency to a newer Kommunicate UI release.

* **Documentation**
  * Added a top changelog entry for React Native Kommunicate Chat v2.3.12 and minor end-of-file formatting adjustment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->