### PR TITLE
Release 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# React Native Kommunicate Chat v2.6.1
+## Android 
+- Settings to hide FAQ status bar  
+- Kommunicate Android SDK version update to 2.16.1
+## iOS
+- List Template UI fixes
+- Kommunicate iOS SDK version update to 7.3.5
+
 # React Native Kommunicate Chat v2.6.0
 ## Android 
 - Markdown format support in messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Settings to hide FAQ status bar  
 - Kommunicate Android SDK version update to 2.16.1
 ## iOS
-- List Template UI fixes
+- List template UI fixes
 - Kommunicate iOS SDK version update to 7.3.5
 
 # React Native Kommunicate Chat v2.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Settings to hide FAQ status bar  
 - Kommunicate Android SDK version update to 2.16.1
 ## iOS
+- Fixed `sendMessage` not attaching `messageMetadata` to the outgoing message payload (requires Kommunicate iOS SDK with `KMMessage.metadata` support in `toKMCoreMessage`)
 - List template UI fixes
 - Kommunicate iOS SDK version update to 7.3.5
 

--- a/RNKommunicateChat.podspec
+++ b/RNKommunicateChat.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m,swift}"
   s.requires_arc = true
   s.dependency 'React'
-  s.dependency 'Kommunicate', '7.3.4'
+  s.dependency 'Kommunicate', '7.3.5'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.kommunicate.sdk:kommunicateui:2.16.0'
+    api 'io.kommunicate.sdk:kommunicateui:2.16.1'
 }

--- a/ios/RNKommunicateChat.swift
+++ b/ios/RNKommunicateChat.swift
@@ -223,14 +223,16 @@ class RNKommunicateChat : RCTEventEmitter, KMPreChatFormViewControllerDelegate, 
             }
             sendMessage.withConversationId(conversationID)
             sendMessage.withText(message)
-            
+
+            let kmMessage = sendMessage.build()
+
             if let messageMetadataStr = (jsonObj["messageMetadata"] as? String)?.data(using: .utf8) {
                 if let messageMetadataDict = try JSONSerialization.jsonObject(with: messageMetadataStr, options : .allowFragments) as? Dictionary<String,Any> {
-                    Kommunicate.defaultConfiguration.messageMetadata = messageMetadataDict
+                    kmMessage.metadata = messageMetadataDict
                 }
             }
-            
-            Kommunicate.sendMessage(message: sendMessage.build()) { error in
+
+            Kommunicate.sendMessage(message: kmMessage) { error in
                 guard error == nil else {
                     callback(["Error", error?.localizedDescription ?? "There is error in sending Mesage to the shared channelID"])
                     return

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-kommunicate-chat",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# React Native Kommunicate Chat v2.6.1
## Android 
- Settings to hide FAQ status bar  
- Kommunicate Android SDK version update to 2.16.1

## iOS
- List template UI fixes
- Kommunicate iOS SDK version update to 7.3.5
- Bug Fix: Fixed `sendMessage` not attaching `messageMetadata` to the outgoing message payload (requires Kommunicate iOS SDK with `KMMessage.metadata` support in `toKMCoreMessage`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release version updated to 2.6.1
  * Android SDK dependency updated to 2.16.1
  * iOS SDK dependency updated to 7.3.5

* **Enhancements**
  * FAQ status bar is now hidden on Android devices

* **Bug Fixes**
  * iOS list template UI layout fixes
  * Outgoing messages on iOS now include message metadata in payloads

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kommunicate-io/Kommunicate-React-Native-SDK/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->